### PR TITLE
Enhance CoxGUI with export and plotting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **Unadjusted & Adjusted models** with one click  
 - **Proportional Hazards check** (Schoenfeld residuals)  
 - **Interactive plots** of hazard ratios & survival curves  
-- ✅ Export results & plots to PNG/CSV  
+- ✅ Export results to text files and save plots as PNG
 
 ---
 
@@ -45,3 +45,6 @@
 Simply run:
 ```bash
 python cox_gui.py
+```
+
+Use the **File** menu to export analysis results or save the latest plot.


### PR DESCRIPTION
## Summary
- add menu bar with file and help options
- enable saving results to text and saving plots as PNG
- provide survival curve plotting
- store the last generated plot for saving
- clarify usage in README

## Testing
- `python -m py_compile cox_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6842ac0bd368832d8321aff7c0e9619b